### PR TITLE
feat: support more flexible event types

### DIFF
--- a/src/event-builder.class.ts
+++ b/src/event-builder.class.ts
@@ -1,11 +1,9 @@
-import { IEvent } from "./event.interface";
-
 export const EventBuilder = <T extends object>() => {
-  const Event = class Event implements IEvent {
+  const Event = class Event {
     constructor(parameters: T) {
       Object.assign(this, parameters);
     }
   };
 
-  return Event as new (args: T) => IEvent & Readonly<T>;
+  return Event as new (args: T) => Readonly<T>;
 };

--- a/src/event.interface.ts
+++ b/src/event.interface.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface IEvent {}

--- a/src/event.module.test.ts
+++ b/src/event.module.test.ts
@@ -3,7 +3,6 @@ import { Test, TestingModule } from "@nestjs/testing";
 
 import { EventModule } from "@/event.module";
 import { EventService } from "@/event.service";
-import { IEvent } from "@/event.interface";
 import { OnEvent } from "@/on-event.decorator";
 
 describe("EventModule", () => {
@@ -11,7 +10,7 @@ describe("EventModule", () => {
   let eventService: EventService;
   let eventMethod: jest.Mock;
 
-  class TestEvent implements IEvent {
+  class TestEvent {
     constructor(public readonly a: number) {}
   }
 

--- a/src/event.service.test.ts
+++ b/src/event.service.test.ts
@@ -2,7 +2,6 @@ import { map } from "rxjs";
 import { TestScheduler } from "rxjs/testing";
 
 import { EventService } from "@/event.service";
-import { IEvent } from "@/event.interface";
 
 describe("EventService", () => {
   let eventService: EventService;
@@ -16,7 +15,7 @@ describe("EventService", () => {
   });
 
   it("subscribes to events", () => {
-    class TestEvent implements IEvent {
+    class TestEvent {
       constructor(public readonly value: number) {}
     }
 

--- a/src/event.service.ts
+++ b/src/event.service.ts
@@ -4,7 +4,6 @@ import { fromEvent, Observable, take } from "rxjs";
 
 import { MODULE_OPTIONS_TOKEN } from "./event.module-definition";
 import { EventModuleOptions } from "./event.module-options";
-import { IEvent } from "./event.interface";
 
 @Injectable()
 export class EventService {
@@ -19,24 +18,24 @@ export class EventService {
     return (this.options.prefix ?? "") + name;
   }
 
-  public on<T extends IEvent>(EventClass: Type<T>): Observable<T> {
+  public on<T>(EventClass: Type<T>): Observable<T> {
     return fromEvent(
       this.emitter,
       this.#getEventName(EventClass.name),
     ) as Observable<T>;
   }
 
-  public once<T extends IEvent>(EventClass: Type<T>): Observable<T> {
+  public once<T>(EventClass: Type<T>): Observable<T> {
     return this.on(EventClass).pipe(take(1));
   }
 
-  public off(EventClass?: Type<IEvent>): void {
+  public off<T>(EventClass?: Type<T>): void {
     this.emitter.removeAllListeners(
       EventClass ? this.#getEventName(EventClass.name) : undefined,
     );
   }
 
-  public emit(event: IEvent): boolean {
+  public emit<T>(event: T): boolean {
     return this.emitter.emit(this.#getEventName(event.constructor.name), event);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,6 @@
 export * from "./event-builder.class";
 export * from "./event.module";
 export * from "./event.module-definition";
-export * from "./event.interface";
 export * from "./event.service";
 export * from "./event.const";
 export * from "./on-event.decorator";

--- a/src/on-event.decorator.ts
+++ b/src/on-event.decorator.ts
@@ -1,7 +1,30 @@
-import { SetMetadata, Type } from "@nestjs/common";
-
 import { EVENT_LISTENER_METADATA } from "@/event.const";
-import { IEvent } from "@/event.interface";
 
-export const OnEvent = (event: Type<IEvent>) =>
-  SetMetadata(EVENT_LISTENER_METADATA, event);
+export const OnEvent = (...event: unknown[]) => {
+  const decoratorFactory: MethodDecorator & {
+    KEY: typeof EVENT_LISTENER_METADATA;
+  } = (target, _key, descriptor) => {
+    if (descriptor) {
+      const existing =
+        Reflect.getMetadata(EVENT_LISTENER_METADATA, descriptor.value) ?? [];
+
+      Reflect.defineMetadata(
+        EVENT_LISTENER_METADATA,
+        [...existing, ...event],
+        descriptor.value,
+      );
+      return descriptor;
+    }
+
+    const existing = Reflect.getMetadata(EVENT_LISTENER_METADATA, target) ?? [];
+
+    Reflect.defineMetadata(
+      EVENT_LISTENER_METADATA,
+      [...existing, ...event],
+      target,
+    );
+    return target;
+  };
+  decoratorFactory.KEY = EVENT_LISTENER_METADATA;
+  return decoratorFactory;
+};


### PR DESCRIPTION
Remove `IEvent`, allowing for more flexible event types: not restricted to classes.

Allow `OnEvent` to take in multiple event types.

Keep track of subscribers to unsubscribe afterwards.